### PR TITLE
Fix delete user controller bug

### DIFF
--- a/src/main/java/d1scodancer/usermicroservice/rest/UserController.java
+++ b/src/main/java/d1scodancer/usermicroservice/rest/UserController.java
@@ -40,7 +40,8 @@ public class UserController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id, @RequestBody User user) {
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/d1scodancer/usermicroservice/UserControllerTest.java
+++ b/src/test/java/d1scodancer/usermicroservice/UserControllerTest.java
@@ -1,0 +1,31 @@
+package d1scodancer.usermicroservice;
+
+import d1scodancer.usermicroservice.rest.UserController;
+import d1scodancer.usermicroservice.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void deleteUserReturnsNoContent() throws Exception {
+        long userId = 1L;
+        mockMvc.perform(delete("/api/v1/users/" + userId))
+                .andExpect(status().isNoContent());
+        Mockito.verify(userService).deleteUser(userId);
+    }
+}


### PR DESCRIPTION
## Summary
- invoke service in delete user endpoint and drop unused body
- add web layer test verifying delete behavior

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685996a00868832ebd0a4e56a110cc54